### PR TITLE
Updated Composer.json with a revised installer_name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "milkyway-multimedia/ss-mwm"            : "~0.3"
   },
   "extra"      : {
-    "installer-name": "shop-order-history",
+    "installer-name": "shop_orderhistory",
     "branch-alias"  : {
       "dev-master": "0.2.x-dev"
     }


### PR DESCRIPTION
I know it is not a convention but most of the main SS Shop modules have the installer name "shop[underscore] module name (one word).  This pull request would make your module fit nicely amongst others in the root directory of a project.  For example:
https://github.com/burnbright/silverstripe-shop-discount/blob/master/composer.json
https://github.com/markguinn/silverstripe-shop-search/blob/master/composer.json
https://github.com/markguinn/silverstripe-shop-ajax/blob/master/composer.json
https://github.com/burnbright/silverstripe-shop-coloredvariations/blob/master/composer.json
https://github.com/burnbright/silverstripe-shop-geocoding/blob/master/composer.json
Thanks
