### PR TITLE
Updated Composer.json for Minimum Stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,6 @@
     "branch-alias"  : {
       "dev-master": "0.2.x-dev"
     }
-  }
+  },
+  "minimum-stability": "dev"
 }


### PR DESCRIPTION
Composer's default minimum stability is stable, which prevents the dependent libraries from being loaded.  Set to 'dev' in composer.json.  Thanks.
